### PR TITLE
Add .html file colouring

### DIFF
--- a/styles/rainbow-tabs.less
+++ b/styles/rainbow-tabs.less
@@ -1,5 +1,6 @@
 @import "rainbow-mixins";
 
+.rainbow-tab('.html', rgb(252,128,27));
 .rainbow-tab('.js', rgb(252,216,76));
 .rainbow-tab('.json', rgb(252,216,76));
 .rainbow-tab('.coffee', rgb(214,233,245));


### PR DESCRIPTION
I saw that you missed a colour of html files - this pull request makes them orange, similar in colour to the HTML5 logo.
