### PR TITLE
add support for julia language extention (.jl)

### DIFF
--- a/styles/rainbow-tabs.less
+++ b/styles/rainbow-tabs.less
@@ -27,3 +27,4 @@
 .rainbow-tab('.pp', #3DFF3D);
 .rainbow-tab('.txt',rgb(255,255,255));
 .rainbow-tab('.elm', #60B5CC);
+.rainbow-tab('.jl', rgb(170,121,193));


### PR DESCRIPTION
The color I use is the "ligh-purple" color of the three-dots logo of Julia.